### PR TITLE
Show connect with me page if only one link is provided 

### DIFF
--- a/components/HumansPage/Profile_v2.tsx
+++ b/components/HumansPage/Profile_v2.tsx
@@ -38,6 +38,8 @@ const Profile: React.FC<ProfileProps> = ({
   instagramUrl,
   githubUrl,
 }) => {
+  const showConnectWithMe: boolean = !!(linkedInUrl || instagramUrl || githubUrl);
+
   return (
     <Box
       sx={{ maxWidth: 800, margin: "auto", padding: 4, typography: "body1" }}
@@ -117,17 +119,17 @@ const Profile: React.FC<ProfileProps> = ({
         ))}
       </List>
 
-      <Divider sx={{ my: 4 }} />
+      {showConnectWithMe && (<Divider sx={{ my: 4 }} />)}
 
       {/* Connect With Me Section */}
-      <Typography
+      {showConnectWithMe && (<Typography
         variant="h4"
         align="center"
         fontFamily="monospace"
         sx={{ fontWeight: "bold", mb: 3, mt: 4 }}
       >
         Connect with me!
-      </Typography>
+      </Typography>)}
       <Stack direction="row" spacing={4} justifyContent="center">
         {linkedInUrl && (
           <MuiLink href={linkedInUrl} target="_blank" rel="noopener">


### PR DESCRIPTION
Previously, the webpage looks like this for those who did not provide any link:

![image](https://github.com/user-attachments/assets/7296a298-2694-4f8b-8427-efa790ad20b4)

Changed it to this:

![image](https://github.com/user-attachments/assets/5984feff-5268-4f49-983f-03fbe63b6d8a)

This fixes #50 
