### PR TITLE
Center the Humans of DE-Scholars text on landing page

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -66,43 +66,43 @@ const Footer: React.FC = () => {
         >
           Connect with Us!
         </Typography>
-          <Link href="https://www.linkedin.com/groups/12487572/" passHref>
-        <Box
-          sx={{
-            display: "flex",
-            alignItems: "center",
-            gap: "8px",
-            marginBottom: "8px",
-          }}
-        >
-          <IconButton sx={{ color: "white" }} aria-label="Facebook">
-            <LinkedInIcon />
-          </IconButton>
+        <Link href="https://www.linkedin.com/groups/12487572/" passHref>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+              marginBottom: "8px",
+            }}
+          >
+            <IconButton sx={{ color: "white" }} aria-label="Facebook">
+              <LinkedInIcon />
+            </IconButton>
             <Typography
-                sx={{
-                    cursor: "pointer",
-                    textDecoration: "none",
-                    "&:hover": { color: "gray" },
-                }}
+              sx={{
+                cursor: "pointer",
+                textDecoration: "none",
+                "&:hover": { color: "gray" },
+              }}
             >
-                E-Scholars & GEP
+              E-Scholars & GEP
             </Typography>
-        </Box>
-              </Link>
+          </Box>
+        </Link>
         <Link href="https://www.instagram.com/nusescholars" passHref>
           <Box sx={{ display: "flex", alignItems: "center", gap: "8px" }}>
             <IconButton sx={{ color: "white" }} aria-label="Instagram">
               <InstagramIcon />
             </IconButton>
-              <Typography
-                  sx={{
-                      cursor: "pointer",
-                      textDecoration: "none",
-                      "&:hover": { color: "gray" },
-                  }}
-              >
-                  @nusescholars
-              </Typography>
+            <Typography
+              sx={{
+                cursor: "pointer",
+                textDecoration: "none",
+                "&:hover": { color: "gray" },
+              }}
+            >
+              @nusescholars
+            </Typography>
           </Box>
         </Link>
       </Box>

--- a/components/LandingPage/LandingGalleryLinks.tsx
+++ b/components/LandingPage/LandingGalleryLinks.tsx
@@ -50,9 +50,9 @@ const LandingGalleryLinks: React.FC<LandingGalleryLinksProps> = ({
                 variant="h3"
                 sx={{
                   position: "absolute",
-                  bottom: "40%",
+                  top: "50%",
                   left: "50%",
-                  transform: "translateX(-50%)",
+                  transform: "translate(-50%, -50%)",
                   color: "white",
                   fontWeight: "bold",
                   textShadow: "0px 2px 4px rgba(0, 0, 0, 0.5)",


### PR DESCRIPTION
Previously, the `Humans of DE-Scholars` text on image looked like this:

![image](https://github.com/user-attachments/assets/bac0cebd-7bb6-46b3-80ce-3f3075e3f1ba)

It was not aligned to the center of the text. However, it now looks like this:

<img width="1262" alt="image" src="https://github.com/user-attachments/assets/c3277ad8-8906-4351-9d8c-e29ff68056a9" />

This would also fix the issue seen on mobile arising from misalignment.